### PR TITLE
:bug: fix installation issue of pimms on PR using colab image

### DIFF
--- a/.github/workflows/test_pkg_on_colab.yaml
+++ b/.github/workflows/test_pkg_on_colab.yaml
@@ -15,6 +15,9 @@ jobs:
         # https://console.cloud.google.com/artifacts/docker/colab-images/europe/public/runtime
         container:
             image: europe-docker.pkg.dev/colab-images/public/runtime:latest
+        defaults:
+          run:
+            shell: bash -el {0}
         steps:
         - uses: actions/checkout@v4
         - name: Install pimms-learn (from branch) and papermill


### PR DESCRIPTION
- locally executing the docker image with cloning the repo and installing pimms works.
- maybe the default shell is not bash? Set the settings as elswhere (miniconda)